### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 > Vectara MCP is also compatible with any MCP client
 >
 
+<a href="https://glama.ai/mcp/servers/@vectara/vectara-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@vectara/vectara-mcp/badge" alt="Vectara server MCP server" />
+</a>
+
 The Model Context Protocol (MCP) is an open standard that enables AI systems to interact seamlessly with various data sources and tools, facilitating secure, two-way connections.
 
 Vectara-MCP provides any agentic application with access to fast, reliable RAG with reduced hallucination, powered by Vectara's Trusted RAG platform, through the MCP protocol.


### PR DESCRIPTION
This PR adds a badge for the [Vectara MCP server](https://glama.ai/mcp/servers/@vectara/vectara-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@vectara/vectara-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@vectara/vectara-mcp/badge" alt="Vectara server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.