### PR TITLE
Add Vectara Agents tools to MCP server

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,560 @@
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from mcp.server.fastmcp import Context
+
+from vectara_mcp.agents import (
+    list_agents,
+    get_agent,
+    create_agent,
+    update_agent,
+    delete_agent,
+    create_session,
+    list_sessions,
+    get_session,
+    delete_session,
+    chat_with_agent,
+    list_events,
+    _extract_chat_response,
+)
+
+
+class TestAgentManagement:
+
+    @pytest.fixture
+    def mock_context(self):
+        context = AsyncMock(spec=Context)
+        context.info = MagicMock()
+        context.report_progress = AsyncMock()
+        return context
+
+    @pytest.fixture(autouse=True)
+    def clear_stored_api_key(self):
+        import vectara_mcp.server
+        vectara_mcp.server._stored_api_key = None
+        yield
+        vectara_mcp.server._stored_api_key = None
+
+    @pytest.fixture
+    def mock_api_key(self):
+        import vectara_mcp.server
+        vectara_mcp.server._stored_api_key = "test-api-key"
+        return "test-api-key"
+
+    # --- list_agents ---
+
+    @pytest.mark.asyncio
+    @patch.dict('os.environ', {}, clear=True)
+    async def test_list_agents_missing_api_key(self, mock_context):
+        result = await list_agents(ctx=mock_context)
+        assert "error" in result
+        assert "API key not configured" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_list_agents_success(self, mock_request, mock_context, mock_api_key):
+        mock_request.return_value = {
+            "agents": [{"key": "agent1", "name": "Test Agent"}],
+            "metadata": {"page_key": "next123"}
+        }
+
+        result = await list_agents(ctx=mock_context)
+
+        assert "agents" in result
+        assert len(result["agents"]) == 1
+        assert result["agents"][0]["key"] == "agent1"
+        mock_request.assert_called_once()
+        call_kwargs = mock_request.call_args
+        assert call_kwargs.kwargs["method"] == "GET"
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_list_agents_with_filters(self, mock_request, mock_context, mock_api_key):
+        mock_request.return_value = {"agents": []}
+
+        await list_agents(ctx=mock_context, filter_name="support", enabled=True, limit=5)
+
+        call_kwargs = mock_request.call_args
+        params = call_kwargs.kwargs["params"]
+        assert params["filter"] == "support"
+        assert params["enabled"] == "true"
+        assert params["limit"] == 5
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_list_agents_with_pagination(self, mock_request, mock_context, mock_api_key):
+        mock_request.return_value = {"agents": []}
+
+        await list_agents(ctx=mock_context, page_key="abc123")
+
+        call_kwargs = mock_request.call_args
+        assert call_kwargs.kwargs["params"]["page_key"] == "abc123"
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_list_agents_exception(self, mock_request, mock_context, mock_api_key):
+        mock_request.side_effect = Exception("Network error")
+
+        result = await list_agents(ctx=mock_context)
+
+        assert result == {"error": "Error with list agents: Network error"}
+
+    # --- get_agent ---
+
+    @pytest.mark.asyncio
+    async def test_get_agent_missing_key(self, mock_context, mock_api_key):
+        result = await get_agent(agent_key="", ctx=mock_context)
+        assert result == {"error": "agent_key is required."}
+
+    @pytest.mark.asyncio
+    @patch.dict('os.environ', {}, clear=True)
+    async def test_get_agent_missing_api_key(self, mock_context):
+        result = await get_agent(agent_key="agent1", ctx=mock_context)
+        assert "API key not configured" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_get_agent_success(self, mock_request, mock_context, mock_api_key):
+        mock_request.return_value = {
+            "key": "agent1",
+            "name": "Support Agent",
+            "tool_configurations": {"search": {"type": "corpora_search"}},
+        }
+
+        result = await get_agent(agent_key="agent1", ctx=mock_context)
+
+        assert result["key"] == "agent1"
+        assert result["name"] == "Support Agent"
+        mock_request.assert_called_once()
+        assert "agents/agent1" in mock_request.call_args.kwargs.get("url", mock_request.call_args[0][0])
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_get_agent_exception(self, mock_request, mock_context, mock_api_key):
+        mock_request.side_effect = Exception("Not found")
+
+        result = await get_agent(agent_key="agent1", ctx=mock_context)
+
+        assert result == {"error": "Error with get agent: Not found"}
+
+    # --- create_agent ---
+
+    @pytest.mark.asyncio
+    async def test_create_agent_missing_name(self, mock_context, mock_api_key):
+        result = await create_agent(name="", ctx=mock_context)
+        assert result == {"error": "name is required."}
+
+    @pytest.mark.asyncio
+    @patch.dict('os.environ', {}, clear=True)
+    async def test_create_agent_missing_api_key(self, mock_context):
+        result = await create_agent(name="My Agent", ctx=mock_context)
+        assert "API key not configured" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_create_agent_minimal(self, mock_request, mock_context, mock_api_key):
+        mock_request.return_value = {"key": "my_agent", "name": "My Agent"}
+
+        result = await create_agent(name="My Agent", ctx=mock_context)
+
+        assert result["name"] == "My Agent"
+        call_kwargs = mock_request.call_args
+        assert call_kwargs.kwargs["method"] == "POST"
+        payload = call_kwargs.kwargs["payload"]
+        assert payload == {"name": "My Agent"}
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_create_agent_full_config(self, mock_request, mock_context, mock_api_key):
+        mock_request.return_value = {"key": "support", "name": "Support Agent"}
+
+        tool_configs = {"search": {"type": "corpora_search"}}
+        model = {"name": "gpt-4o", "parameters": {"temperature": 0.7}}
+        steps = {"main": {"instructions": [{"type": "inline", "template": "Help the user"}]}}
+
+        result = await create_agent(
+            name="Support Agent",
+            ctx=mock_context,
+            key="support",
+            description="Handles support",
+            tool_configurations=tool_configs,
+            model=model,
+            first_step_name="main",
+            steps=steps,
+            metadata={"team": "support"},
+        )
+
+        payload = mock_request.call_args.kwargs["payload"]
+        assert payload["key"] == "support"
+        assert payload["name"] == "Support Agent"
+        assert payload["description"] == "Handles support"
+        assert payload["tool_configurations"] == tool_configs
+        assert payload["model"] == model
+        assert payload["first_step_name"] == "main"
+        assert payload["steps"] == steps
+        assert payload["metadata"] == {"team": "support"}
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_create_agent_exception(self, mock_request, mock_context, mock_api_key):
+        mock_request.side_effect = Exception("Bad request")
+
+        result = await create_agent(name="Agent", ctx=mock_context)
+
+        assert result == {"error": "Error with create agent: Bad request"}
+
+    # --- update_agent ---
+
+    @pytest.mark.asyncio
+    async def test_update_agent_missing_key(self, mock_context, mock_api_key):
+        result = await update_agent(agent_key="", ctx=mock_context, name="New Name")
+        assert result == {"error": "agent_key is required."}
+
+    @pytest.mark.asyncio
+    async def test_update_agent_no_fields(self, mock_context, mock_api_key):
+        result = await update_agent(agent_key="agent1", ctx=mock_context)
+        assert result == {"error": "At least one field to update is required."}
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_update_agent_success(self, mock_request, mock_context, mock_api_key):
+        mock_request.return_value = {"key": "agent1", "name": "Updated Name"}
+
+        result = await update_agent(
+            agent_key="agent1", ctx=mock_context, name="Updated Name", enabled=False
+        )
+
+        assert result["name"] == "Updated Name"
+        call_kwargs = mock_request.call_args
+        assert call_kwargs.kwargs["method"] == "PATCH"
+        payload = call_kwargs.kwargs["payload"]
+        assert payload["name"] == "Updated Name"
+        assert payload["enabled"] is False
+
+    # --- delete_agent ---
+
+    @pytest.mark.asyncio
+    async def test_delete_agent_missing_key(self, mock_context, mock_api_key):
+        result = await delete_agent(agent_key="", ctx=mock_context)
+        assert result == {"error": "agent_key is required."}
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_delete_agent_success(self, mock_request, mock_context, mock_api_key):
+        mock_request.return_value = {"status": "deleted"}
+
+        result = await delete_agent(agent_key="agent1", ctx=mock_context)
+
+        assert result == {"status": "deleted"}
+        assert mock_request.call_args.kwargs["method"] == "DELETE"
+
+
+class TestSessionManagement:
+
+    @pytest.fixture
+    def mock_context(self):
+        context = AsyncMock(spec=Context)
+        context.info = MagicMock()
+        context.report_progress = AsyncMock()
+        return context
+
+    @pytest.fixture(autouse=True)
+    def clear_stored_api_key(self):
+        import vectara_mcp.server
+        vectara_mcp.server._stored_api_key = None
+        yield
+        vectara_mcp.server._stored_api_key = None
+
+    @pytest.fixture
+    def mock_api_key(self):
+        import vectara_mcp.server
+        vectara_mcp.server._stored_api_key = "test-api-key"
+        return "test-api-key"
+
+    # --- create_session ---
+
+    @pytest.mark.asyncio
+    async def test_create_session_missing_agent_key(self, mock_context, mock_api_key):
+        result = await create_session(agent_key="", ctx=mock_context)
+        assert result == {"error": "agent_key is required."}
+
+    @pytest.mark.asyncio
+    @patch.dict('os.environ', {}, clear=True)
+    async def test_create_session_missing_api_key(self, mock_context):
+        result = await create_session(agent_key="agent1", ctx=mock_context)
+        assert "API key not configured" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_create_session_minimal(self, mock_request, mock_context, mock_api_key):
+        mock_request.return_value = {"key": "sess_abc", "agent_key": "agent1"}
+
+        result = await create_session(agent_key="agent1", ctx=mock_context)
+
+        assert result["key"] == "sess_abc"
+        payload = mock_request.call_args.kwargs["payload"]
+        assert payload == {}
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_create_session_with_metadata(self, mock_request, mock_context, mock_api_key):
+        mock_request.return_value = {"key": "my_session", "agent_key": "agent1"}
+
+        await create_session(
+            agent_key="agent1",
+            ctx=mock_context,
+            session_key="my_session",
+            name="Support Session",
+            metadata={"customer_id": "123"},
+            tti_minutes=60,
+        )
+
+        payload = mock_request.call_args.kwargs["payload"]
+        assert payload["key"] == "my_session"
+        assert payload["name"] == "Support Session"
+        assert payload["metadata"] == {"customer_id": "123"}
+        assert payload["tti_minutes"] == 60
+
+    # --- list_sessions ---
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_missing_agent_key(self, mock_context, mock_api_key):
+        result = await list_sessions(agent_key="", ctx=mock_context)
+        assert result == {"error": "agent_key is required."}
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_list_sessions_success(self, mock_request, mock_context, mock_api_key):
+        mock_request.return_value = {
+            "sessions": [{"key": "sess1"}, {"key": "sess2"}]
+        }
+
+        result = await list_sessions(agent_key="agent1", ctx=mock_context)
+
+        assert len(result["sessions"]) == 2
+        assert mock_request.call_args.kwargs["method"] == "GET"
+
+    # --- get_session ---
+
+    @pytest.mark.asyncio
+    async def test_get_session_missing_keys(self, mock_context, mock_api_key):
+        result = await get_session(agent_key="", session_key="sess1", ctx=mock_context)
+        assert result == {"error": "agent_key and session_key are required."}
+
+        result = await get_session(agent_key="agent1", session_key="", ctx=mock_context)
+        assert result == {"error": "agent_key and session_key are required."}
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_get_session_success(self, mock_request, mock_context, mock_api_key):
+        mock_request.return_value = {
+            "key": "sess1",
+            "agent_key": "agent1",
+            "session_context_usage": {"total_tokens": 150},
+        }
+
+        result = await get_session(agent_key="agent1", session_key="sess1", ctx=mock_context)
+
+        assert result["key"] == "sess1"
+        assert result["session_context_usage"]["total_tokens"] == 150
+
+    # --- delete_session ---
+
+    @pytest.mark.asyncio
+    async def test_delete_session_missing_keys(self, mock_context, mock_api_key):
+        result = await delete_session(agent_key="agent1", session_key="", ctx=mock_context)
+        assert result == {"error": "agent_key and session_key are required."}
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_delete_session_success(self, mock_request, mock_context, mock_api_key):
+        mock_request.return_value = {"status": "deleted"}
+
+        result = await delete_session(agent_key="agent1", session_key="sess1", ctx=mock_context)
+
+        assert result == {"status": "deleted"}
+        assert mock_request.call_args.kwargs["method"] == "DELETE"
+
+
+class TestChatAndEvents:
+
+    @pytest.fixture
+    def mock_context(self):
+        context = AsyncMock(spec=Context)
+        context.info = MagicMock()
+        context.report_progress = AsyncMock()
+        return context
+
+    @pytest.fixture(autouse=True)
+    def clear_stored_api_key(self):
+        import vectara_mcp.server
+        vectara_mcp.server._stored_api_key = None
+        yield
+        vectara_mcp.server._stored_api_key = None
+
+    @pytest.fixture
+    def mock_api_key(self):
+        import vectara_mcp.server
+        vectara_mcp.server._stored_api_key = "test-api-key"
+        return "test-api-key"
+
+    # --- chat_with_agent ---
+
+    @pytest.mark.asyncio
+    async def test_chat_missing_keys(self, mock_context, mock_api_key):
+        result = await chat_with_agent(
+            agent_key="", session_key="sess1", message="hi", ctx=mock_context
+        )
+        assert result == {"error": "agent_key and session_key are required."}
+
+    @pytest.mark.asyncio
+    async def test_chat_missing_message(self, mock_context, mock_api_key):
+        result = await chat_with_agent(
+            agent_key="agent1", session_key="sess1", message="", ctx=mock_context
+        )
+        assert result == {"error": "message is required."}
+
+    @pytest.mark.asyncio
+    @patch.dict('os.environ', {}, clear=True)
+    async def test_chat_missing_api_key(self, mock_context):
+        result = await chat_with_agent(
+            agent_key="agent1", session_key="sess1", message="hi", ctx=mock_context
+        )
+        assert "API key not configured" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_chat_success_simple(self, mock_request, mock_context, mock_api_key):
+        mock_request.return_value = {
+            "events": [
+                {"type": "agent_output", "id": "evt1", "content": "Hello! How can I help?"}
+            ]
+        }
+
+        result = await chat_with_agent(
+            agent_key="agent1", session_key="sess1", message="hi", ctx=mock_context
+        )
+
+        assert result["agent_output"] == "Hello! How can I help?"
+        assert "tool_calls" not in result
+        assert len(result["events_summary"]) == 1
+
+        payload = mock_request.call_args.kwargs["payload"]
+        assert payload["type"] == "input_message"
+        assert payload["messages"][0]["content"] == "hi"
+        assert payload["stream_response"] is False
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_chat_success_with_tool_calls(self, mock_request, mock_context, mock_api_key):
+        mock_request.return_value = {
+            "events": [
+                {
+                    "type": "tool_input",
+                    "id": "evt1",
+                    "tool_config_name": "search",
+                    "arguments": {"query": "vectara pricing"},
+                },
+                {
+                    "type": "tool_output",
+                    "id": "evt2",
+                    "output": "Vectara offers free and paid plans.",
+                },
+                {
+                    "type": "agent_output",
+                    "id": "evt3",
+                    "content": "Based on my search, Vectara offers free and paid plans.",
+                },
+            ]
+        }
+
+        result = await chat_with_agent(
+            agent_key="agent1", session_key="sess1", message="pricing?", ctx=mock_context
+        )
+
+        assert "Based on my search" in result["agent_output"]
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["tool"] == "search"
+        assert result["tool_calls"][0]["arguments"] == {"query": "vectara pricing"}
+        assert result["tool_calls"][0]["output"] == "Vectara offers free and paid plans."
+        assert len(result["events_summary"]) == 3
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_chat_exception(self, mock_request, mock_context, mock_api_key):
+        mock_request.side_effect = Exception("Timeout")
+
+        result = await chat_with_agent(
+            agent_key="agent1", session_key="sess1", message="hi", ctx=mock_context
+        )
+
+        assert result == {"error": "Error with chat with agent: Timeout"}
+
+    # --- _extract_chat_response ---
+
+    def test_extract_empty_events(self):
+        result = _extract_chat_response({"events": []})
+        assert result == {"events": []}
+
+    def test_extract_no_events_key(self):
+        raw = {"some_other_field": "value"}
+        result = _extract_chat_response(raw)
+        assert result == raw
+
+    def test_extract_structured_output(self):
+        result = _extract_chat_response({
+            "events": [
+                {"type": "structured_output", "id": "evt1", "fields": {"intent": "billing"}}
+            ]
+        })
+        assert '"intent"' in result["agent_output"]
+        assert '"billing"' in result["agent_output"]
+
+    # --- list_events ---
+
+    @pytest.mark.asyncio
+    async def test_list_events_missing_keys(self, mock_context, mock_api_key):
+        result = await list_events(agent_key="", session_key="sess1", ctx=mock_context)
+        assert result == {"error": "agent_key and session_key are required."}
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_list_events_success(self, mock_request, mock_context, mock_api_key):
+        mock_request.return_value = {
+            "events": [
+                {"type": "input_message", "id": "evt1"},
+                {"type": "agent_output", "id": "evt2"},
+            ]
+        }
+
+        result = await list_events(
+            agent_key="agent1", session_key="sess1", ctx=mock_context
+        )
+
+        assert len(result["events"]) == 2
+        assert mock_request.call_args.kwargs["method"] == "GET"
+        assert mock_request.call_args.kwargs["params"]["limit"] == 20
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_list_events_with_pagination(self, mock_request, mock_context, mock_api_key):
+        mock_request.return_value = {"events": []}
+
+        await list_events(
+            agent_key="agent1", session_key="sess1", ctx=mock_context,
+            limit=5, page_key="page2"
+        )
+
+        params = mock_request.call_args.kwargs["params"]
+        assert params["limit"] == 5
+        assert params["page_key"] == "page2"
+
+    @pytest.mark.asyncio
+    @patch('vectara_mcp.agents._make_api_request')
+    async def test_list_events_exception(self, mock_request, mock_context, mock_api_key):
+        mock_request.side_effect = Exception("Server error")
+
+        result = await list_events(
+            agent_key="agent1", session_key="sess1", ctx=mock_context
+        )
+
+        assert result == {"error": "Error with list events: Server error"}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,6 +12,19 @@ from vectara_mcp.server import (
     correct_hallucinations,
     eval_factual_consistency
 )
+from vectara_mcp.agents import (
+    list_agents,
+    get_agent,
+    create_agent,
+    update_agent,
+    delete_agent,
+    create_session,
+    list_sessions,
+    get_session,
+    delete_session,
+    chat_with_agent,
+    list_events,
+)
 
 # Load environment variables
 load_dotenv()
@@ -220,3 +233,318 @@ class TestVectaraIntegration:
                 print(f"   Value: {result}")
 
         print("\n" + "="*80)
+
+
+# Agent integration tests require API key + an agent key
+AGENT_KEY = os.getenv("VECTARA_AGENT_KEY", "")
+
+agent_pytestmark = pytest.mark.skipif(
+    not API_KEY or not AGENT_KEY,
+    reason="Agent integration tests require VECTARA_API_KEY and VECTARA_AGENT_KEY in .env file"
+)
+
+
+@agent_pytestmark
+class TestAgentIntegration:
+    """Integration tests for Vectara Agent MCP tools using real API endpoints.
+
+    Set VECTARA_API_KEY and VECTARA_AGENT_KEY in .env to run these tests.
+    """
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def cleanup_connection_manager(self):
+        from vectara_mcp.connection_manager import ConnectionManager, connection_manager
+        await connection_manager.close()
+        ConnectionManager.reset_instance()
+        yield
+        await connection_manager.close()
+        ConnectionManager.reset_instance()
+
+    @pytest.fixture(autouse=True)
+    def set_api_key(self):
+        import vectara_mcp.server
+        vectara_mcp.server._stored_api_key = API_KEY
+        yield
+        vectara_mcp.server._stored_api_key = None
+
+    @pytest.fixture
+    def mock_context(self):
+        context = AsyncMock(spec=Context)
+        context.info = MagicMock()
+        context.report_progress = AsyncMock()
+        return context
+
+    @pytest.mark.asyncio
+    async def test_list_agents_integration(self, mock_context):
+        result = await list_agents(ctx=mock_context, limit=5)
+
+        print(f"\n=== list_agents result ===")
+        print(f"Result: {json.dumps(result, indent=2, default=str)}")
+
+        assert isinstance(result, dict)
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_get_agent_integration(self, mock_context):
+        result = await get_agent(agent_key=AGENT_KEY, ctx=mock_context)
+
+        print(f"\n=== get_agent result ===")
+        print(f"Result keys: {list(result.keys())}")
+
+        assert isinstance(result, dict)
+        assert "error" not in result
+        assert result.get("key") == AGENT_KEY
+
+    @pytest.mark.asyncio
+    async def test_agent_session_chat_lifecycle(self, mock_context):
+        """End-to-end: create session -> chat -> list events -> delete session."""
+        import time
+        session_result = await create_session(
+            agent_key=AGENT_KEY,
+            ctx=mock_context,
+            name=f"mcp-integ-test-{int(time.time())}",
+        )
+
+        print(f"\n=== create_session result ===")
+        print(f"Result: {json.dumps(session_result, indent=2, default=str)}")
+
+        assert isinstance(session_result, dict)
+        assert "error" not in session_result
+        session_key = session_result.get("key")
+        assert session_key
+
+        try:
+            sessions_result = await list_sessions(
+                agent_key=AGENT_KEY, ctx=mock_context, limit=5
+            )
+            assert "error" not in sessions_result
+
+            get_result = await get_session(
+                agent_key=AGENT_KEY, session_key=session_key, ctx=mock_context
+            )
+            assert "error" not in get_result
+            assert get_result.get("key") == session_key
+
+            chat_result = await chat_with_agent(
+                agent_key=AGENT_KEY,
+                session_key=session_key,
+                message="Hello, this is an integration test. Please reply briefly.",
+                ctx=mock_context,
+            )
+
+            print(f"\n=== chat_with_agent result ===")
+            print(f"Result: {json.dumps(chat_result, indent=2, default=str)}")
+
+            assert isinstance(chat_result, dict)
+            assert "error" not in chat_result
+            assert chat_result.get("agent_output")
+
+            events_result = await list_events(
+                agent_key=AGENT_KEY, session_key=session_key, ctx=mock_context
+            )
+
+            print(f"\n=== list_events result ===")
+            print(f"Result: {json.dumps(events_result, indent=2, default=str)}")
+
+            assert "error" not in events_result
+
+        finally:
+            delete_result = await delete_session(
+                agent_key=AGENT_KEY, session_key=session_key, ctx=mock_context
+            )
+            print(f"\n=== delete_session result ===")
+            print(f"Result: {json.dumps(delete_result, indent=2, default=str)}")
+
+    @pytest.mark.asyncio
+    async def test_create_and_delete_agent(self, mock_context):
+        """End-to-end: create agent -> verify -> update -> delete."""
+        create_result = await create_agent(
+            name="MCP Integration Test Agent",
+            ctx=mock_context,
+            description="Temporary agent created by integration tests",
+            model={"name": "gpt-4o", "parameters": {"temperature": 0.5}},
+            first_step_name="main",
+            steps={
+                "main": {
+                    "instructions": [
+                        {"type": "inline", "name": "system", "template": "You are a helpful assistant."}
+                    ],
+                    "output_parser": {"type": "default"},
+                }
+            },
+        )
+
+        print(f"\n=== create_agent result ===")
+        print(f"Result: {json.dumps(create_result, indent=2, default=str)}")
+
+        assert isinstance(create_result, dict)
+        assert "error" not in create_result
+        new_agent_key = create_result.get("key")
+        assert new_agent_key
+
+        try:
+            get_result = await get_agent(agent_key=new_agent_key, ctx=mock_context)
+            assert get_result.get("name") == "MCP Integration Test Agent"
+
+            update_result = await update_agent(
+                agent_key=new_agent_key,
+                ctx=mock_context,
+                description="Updated by integration test",
+            )
+            assert "error" not in update_result
+
+        finally:
+            delete_result = await delete_agent(agent_key=new_agent_key, ctx=mock_context)
+            print(f"\n=== delete_agent result ===")
+            print(f"Result: {json.dumps(delete_result, indent=2, default=str)}")
+
+    @pytest.mark.asyncio
+    async def test_list_agents_pagination(self, mock_context):
+        """Test that list_agents respects limit and returns page_key."""
+        result = await list_agents(ctx=mock_context, limit=1)
+
+        assert "error" not in result
+        agents = result.get("agents", [])
+        assert len(agents) <= 1
+
+        page_key = result.get("metadata", {}).get("page_key", "")
+        if page_key:
+            result2 = await list_agents(ctx=mock_context, limit=1, page_key=page_key)
+            assert "error" not in result2
+
+    @pytest.mark.asyncio
+    async def test_list_agents_filter(self, mock_context):
+        """Test filtering agents by name."""
+        result = await list_agents(ctx=mock_context, filter_name="SDK")
+
+        assert "error" not in result
+        agents = result.get("agents", [])
+        for agent in agents:
+            assert "SDK" in agent.get("name", "") or "sdk" in agent.get("name", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_get_agent_not_found(self, mock_context):
+        """Test get_agent with a non-existent key."""
+        result = await get_agent(agent_key="nonexistent_agent_key_12345", ctx=mock_context)
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_update_agent_integration(self, mock_context):
+        """Test updating an existing agent's description."""
+        import time
+        original = await get_agent(agent_key=AGENT_KEY, ctx=mock_context)
+        original_desc = original.get("description", "")
+
+        new_desc = f"Updated at {int(time.time())} by integration test"
+        result = await update_agent(
+            agent_key=AGENT_KEY, ctx=mock_context, description=new_desc,
+        )
+
+        assert "error" not in result
+
+        # Verify the update took effect
+        updated = await get_agent(agent_key=AGENT_KEY, ctx=mock_context)
+        assert updated.get("description") == new_desc
+
+        # Restore original
+        await update_agent(
+            agent_key=AGENT_KEY, ctx=mock_context, description=original_desc,
+        )
+
+    @pytest.mark.asyncio
+    async def test_session_with_metadata(self, mock_context):
+        """Test creating a session with metadata and verifying it's stored."""
+        import time
+        metadata = {"customer_id": "test-123", "source": "integration_test"}
+        session_result = await create_session(
+            agent_key=AGENT_KEY,
+            ctx=mock_context,
+            name=f"meta-test-{int(time.time())}",
+            metadata=metadata,
+        )
+
+        assert "error" not in session_result
+        session_key = session_result.get("key")
+        assert session_key
+
+        try:
+            get_result = await get_session(
+                agent_key=AGENT_KEY, session_key=session_key, ctx=mock_context
+            )
+            assert "error" not in get_result
+            assert get_result.get("metadata", {}).get("customer_id") == "test-123"
+            assert get_result.get("metadata", {}).get("source") == "integration_test"
+        finally:
+            await delete_session(
+                agent_key=AGENT_KEY, session_key=session_key, ctx=mock_context
+            )
+
+    @pytest.mark.asyncio
+    async def test_multi_turn_chat(self, mock_context):
+        """Test multiple chat turns maintain conversation context."""
+        import time
+        session_result = await create_session(
+            agent_key=AGENT_KEY,
+            ctx=mock_context,
+            name=f"multi-turn-{int(time.time())}",
+        )
+
+        assert "error" not in session_result
+        session_key = session_result["key"]
+
+        try:
+            # Turn 1
+            chat1 = await chat_with_agent(
+                agent_key=AGENT_KEY, session_key=session_key,
+                message="Remember this number: 42.", ctx=mock_context,
+            )
+            assert "error" not in chat1
+            assert chat1.get("agent_output")
+
+            # Turn 2 — ask about context from turn 1
+            chat2 = await chat_with_agent(
+                agent_key=AGENT_KEY, session_key=session_key,
+                message="What number did I ask you to remember?", ctx=mock_context,
+            )
+            assert "error" not in chat2
+            assert chat2.get("agent_output")
+            assert "42" in chat2["agent_output"]
+
+            # Verify events accumulated
+            events_result = await list_events(
+                agent_key=AGENT_KEY, session_key=session_key, ctx=mock_context
+            )
+            assert len(events_result.get("events", [])) >= 4
+        finally:
+            await delete_session(
+                agent_key=AGENT_KEY, session_key=session_key, ctx=mock_context
+            )
+
+    @pytest.mark.asyncio
+    async def test_list_events_pagination(self, mock_context):
+        """Test listing events with limit."""
+        import time
+        session_result = await create_session(
+            agent_key=AGENT_KEY, ctx=mock_context,
+            name=f"evt-page-{int(time.time())}",
+        )
+        session_key = session_result["key"]
+
+        try:
+            await chat_with_agent(
+                agent_key=AGENT_KEY, session_key=session_key,
+                message="Hello", ctx=mock_context,
+            )
+
+            result = await list_events(
+                agent_key=AGENT_KEY, session_key=session_key,
+                ctx=mock_context, limit=1,
+            )
+
+            assert "error" not in result
+            assert len(result.get("events", [])) <= 1
+        finally:
+            await delete_session(
+                agent_key=AGENT_KEY, session_key=session_key, ctx=mock_context
+            )

--- a/vectara_mcp/agents.py
+++ b/vectara_mcp/agents.py
@@ -1,0 +1,604 @@
+"""Vectara Agents tools for the MCP server.
+
+Provides tools for managing agents, sessions, and chat interactions
+via the Vectara v2 API.
+"""
+
+import json
+
+from mcp.server.fastmcp import Context
+
+import vectara_mcp.server as _server
+from vectara_mcp.server import (
+    mcp, _make_api_request, _get_api_key, _format_error, API_KEY_ERROR_MESSAGE
+)
+
+
+def _validate_api_key_available() -> str | None:
+    """Return error message if no API key is available, None otherwise."""
+    if not _get_api_key():
+        return API_KEY_ERROR_MESSAGE
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Agent Management Tools
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def list_agents(
+    ctx: Context,
+    filter_name: str = "",
+    enabled: bool | None = None,
+    limit: int = 10,
+    page_key: str = "",
+) -> dict:
+    """List agents in the Vectara account.
+
+    Args:
+        filter_name: str, Filter agents by name (substring match). Optional.
+        enabled: bool, Filter by enabled status. Optional.
+        limit: int, Max agents to return per page. Default 10.
+        page_key: str, Pagination key from a previous response. Optional.
+
+    Returns:
+        dict: List of agents and pagination metadata.
+    """
+    error = _validate_api_key_available()
+    if error:
+        return {"error": error}
+
+    if ctx:
+        ctx.info("Listing agents")
+
+    try:
+        params = {"limit": limit}
+        if filter_name:
+            params["filter"] = filter_name
+        if enabled is not None:
+            params["enabled"] = str(enabled).lower()
+        if page_key:
+            params["page_key"] = page_key
+
+        return await _make_api_request(
+            f"{_server.VECTARA_BASE_URL}/agents",
+            ctx=ctx,
+            error_context="list agents",
+            method="GET",
+            params=params,
+        )
+    except Exception as e:
+        return {"error": _format_error("list agents", e)}
+
+
+@mcp.tool()
+async def get_agent(
+    agent_key: str,
+    ctx: Context,
+) -> dict:
+    """Get full details of a Vectara agent.
+
+    Args:
+        agent_key: str, The unique key of the agent. Required.
+
+    Returns:
+        dict: Agent configuration including tools, steps, model, and metadata.
+    """
+    error = _validate_api_key_available()
+    if error:
+        return {"error": error}
+
+    if not agent_key:
+        return {"error": "agent_key is required."}
+
+    if ctx:
+        ctx.info(f"Getting agent: {agent_key}")
+
+    try:
+        return await _make_api_request(
+            f"{_server.VECTARA_BASE_URL}/agents/{agent_key}",
+            ctx=ctx,
+            error_context="get agent",
+            method="GET",
+        )
+    except Exception as e:
+        return {"error": _format_error("get agent", e)}
+
+
+@mcp.tool()
+async def create_agent(
+    name: str,
+    ctx: Context,
+    key: str = "",
+    description: str = "",
+    tool_configurations: dict = None,
+    model: dict = None,
+    first_step_name: str = "",
+    steps: dict = None,
+    skills: dict = None,
+    metadata: dict = None,
+    guardrails: dict = None,
+) -> dict:
+    """Create a new Vectara agent.
+
+    Args:
+        name: str, Human-readable agent name. Required.
+        key: str, Unique agent key (alphanumeric, max 50 chars). Optional, auto-generated if empty.
+        description: str, Description of the agent's purpose. Optional.
+        tool_configurations: dict, Map of tool name to tool config. Each config needs a "type"
+            field. Common types: "corpora_search", "web_search", "sub_agent", "lambda".
+            Example: {"search": {"type": "corpora_search", "query_configuration": {"search": {"corpora": [{"corpus_key": "my_corpus"}]}}}}
+        model: dict, LLM configuration. Example: {"name": "gpt-4o", "parameters": {"temperature": 0.7}}
+        first_step_name: str, Entry point step name. Optional.
+        steps: dict, Map of step name to step config with instructions, output_parser, etc. Optional.
+        skills: dict, Map of skill name to skill config with description and content. Optional.
+        metadata: dict, Arbitrary key-value pairs. Optional.
+        guardrails: dict, Safety check configurations. Optional.
+
+    Returns:
+        dict: The created agent object.
+    """
+    error = _validate_api_key_available()
+    if error:
+        return {"error": error}
+
+    if not name:
+        return {"error": "name is required."}
+
+    if ctx:
+        ctx.info(f"Creating agent: {name}")
+
+    try:
+        payload = {"name": name}
+        if key:
+            payload["key"] = key
+        if description:
+            payload["description"] = description
+        if tool_configurations:
+            payload["tool_configurations"] = tool_configurations
+        if model:
+            payload["model"] = model
+        if first_step_name:
+            payload["first_step_name"] = first_step_name
+        if steps:
+            payload["steps"] = steps
+        if skills:
+            payload["skills"] = skills
+        if metadata:
+            payload["metadata"] = metadata
+        if guardrails:
+            payload["guardrails"] = guardrails
+
+        return await _make_api_request(
+            f"{_server.VECTARA_BASE_URL}/agents",
+            payload=payload,
+            ctx=ctx,
+            error_context="create agent",
+            method="POST",
+        )
+    except Exception as e:
+        return {"error": _format_error("create agent", e)}
+
+
+@mcp.tool()
+async def update_agent(
+    agent_key: str,
+    ctx: Context,
+    name: str | None = None,
+    description: str | None = None,
+    enabled: bool | None = None,
+    tool_configurations: dict = None,
+    model: dict = None,
+    steps: dict = None,
+    skills: dict = None,
+    metadata: dict = None,
+) -> dict:
+    """Update an existing Vectara agent (partial update).
+
+    Args:
+        agent_key: str, The unique key of the agent to update. Required.
+        name: str, New agent name. Optional.
+        description: str, New description (pass empty string to clear). Optional.
+        enabled: bool, Enable or disable the agent. Optional.
+        tool_configurations: dict, Updated tool configurations. Optional.
+        model: dict, Updated LLM configuration. Optional.
+        steps: dict, Updated step configurations. Optional.
+        skills: dict, Updated skills. Optional.
+        metadata: dict, Updated metadata. Optional.
+
+    Returns:
+        dict: The updated agent object.
+    """
+    error = _validate_api_key_available()
+    if error:
+        return {"error": error}
+
+    if not agent_key:
+        return {"error": "agent_key is required."}
+
+    if ctx:
+        ctx.info(f"Updating agent: {agent_key}")
+
+    try:
+        payload = {}
+        if name is not None:
+            payload["name"] = name
+        if description is not None:
+            payload["description"] = description
+        if enabled is not None:
+            payload["enabled"] = enabled
+        if tool_configurations is not None:
+            payload["tool_configurations"] = tool_configurations
+        if model is not None:
+            payload["model"] = model
+        if steps is not None:
+            payload["steps"] = steps
+        if skills is not None:
+            payload["skills"] = skills
+        if metadata is not None:
+            payload["metadata"] = metadata
+
+        if not payload:
+            return {"error": "At least one field to update is required."}
+
+        return await _make_api_request(
+            f"{_server.VECTARA_BASE_URL}/agents/{agent_key}",
+            payload=payload,
+            ctx=ctx,
+            error_context="update agent",
+            method="PATCH",
+        )
+    except Exception as e:
+        return {"error": _format_error("update agent", e)}
+
+
+@mcp.tool()
+async def delete_agent(
+    agent_key: str,
+    ctx: Context,
+) -> dict:
+    """Delete a Vectara agent.
+
+    Args:
+        agent_key: str, The unique key of the agent to delete. Required.
+
+    Returns:
+        dict: Confirmation of deletion.
+    """
+    error = _validate_api_key_available()
+    if error:
+        return {"error": error}
+
+    if not agent_key:
+        return {"error": "agent_key is required."}
+
+    if ctx:
+        ctx.info(f"Deleting agent: {agent_key}")
+
+    try:
+        return await _make_api_request(
+            f"{_server.VECTARA_BASE_URL}/agents/{agent_key}",
+            ctx=ctx,
+            error_context="delete agent",
+            method="DELETE",
+        )
+    except Exception as e:
+        return {"error": _format_error("delete agent", e)}
+
+
+# ---------------------------------------------------------------------------
+# Session Management Tools
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def create_session(
+    agent_key: str,
+    ctx: Context,
+    session_key: str = "",
+    name: str = "",
+    description: str = "",
+    metadata: dict = None,
+    tti_minutes: int = 0,
+) -> dict:
+    """Create a new chat session for a Vectara agent.
+
+    Args:
+        agent_key: str, The agent to create a session for. Required.
+        session_key: str, Custom session key. Optional, auto-generated if empty.
+        name: str, Session name. Optional.
+        description: str, Session description. Optional.
+        metadata: dict, Session metadata accessible to the agent. Optional.
+        tti_minutes: int, Time-to-idle in minutes before auto-delete (0 = never). Default 0.
+
+    Returns:
+        dict: The created session object with key and details.
+    """
+    error = _validate_api_key_available()
+    if error:
+        return {"error": error}
+
+    if not agent_key:
+        return {"error": "agent_key is required."}
+
+    if ctx:
+        ctx.info(f"Creating session for agent: {agent_key}")
+
+    try:
+        payload = {}
+        if session_key:
+            payload["key"] = session_key
+        if name:
+            payload["name"] = name
+        if description:
+            payload["description"] = description
+        if metadata:
+            payload["metadata"] = metadata
+        if tti_minutes:
+            payload["tti_minutes"] = tti_minutes
+
+        return await _make_api_request(
+            f"{_server.VECTARA_BASE_URL}/agents/{agent_key}/sessions",
+            payload=payload,
+            ctx=ctx,
+            error_context="create session",
+            method="POST",
+        )
+    except Exception as e:
+        return {"error": _format_error("create session", e)}
+
+
+@mcp.tool()
+async def list_sessions(
+    agent_key: str,
+    ctx: Context,
+    limit: int = 10,
+    page_key: str = "",
+) -> dict:
+    """List sessions for a Vectara agent.
+
+    Args:
+        agent_key: str, The agent to list sessions for. Required.
+        limit: int, Max sessions to return per page. Default 10.
+        page_key: str, Pagination key from a previous response. Optional.
+
+    Returns:
+        dict: List of sessions and pagination metadata.
+    """
+    error = _validate_api_key_available()
+    if error:
+        return {"error": error}
+
+    if not agent_key:
+        return {"error": "agent_key is required."}
+
+    if ctx:
+        ctx.info(f"Listing sessions for agent: {agent_key}")
+
+    try:
+        params = {"limit": limit}
+        if page_key:
+            params["page_key"] = page_key
+
+        return await _make_api_request(
+            f"{_server.VECTARA_BASE_URL}/agents/{agent_key}/sessions",
+            ctx=ctx,
+            error_context="list sessions",
+            method="GET",
+            params=params,
+        )
+    except Exception as e:
+        return {"error": _format_error("list sessions", e)}
+
+
+@mcp.tool()
+async def get_session(
+    agent_key: str,
+    session_key: str,
+    ctx: Context,
+) -> dict:
+    """Get details of a specific agent session.
+
+    Args:
+        agent_key: str, The agent key. Required.
+        session_key: str, The session key. Required.
+
+    Returns:
+        dict: Session details including metadata and context usage.
+    """
+    error = _validate_api_key_available()
+    if error:
+        return {"error": error}
+
+    if not agent_key or not session_key:
+        return {"error": "agent_key and session_key are required."}
+
+    if ctx:
+        ctx.info(f"Getting session {session_key} for agent {agent_key}")
+
+    try:
+        return await _make_api_request(
+            f"{_server.VECTARA_BASE_URL}/agents/{agent_key}/sessions/{session_key}",
+            ctx=ctx,
+            error_context="get session",
+            method="GET",
+        )
+    except Exception as e:
+        return {"error": _format_error("get session", e)}
+
+
+@mcp.tool()
+async def delete_session(
+    agent_key: str,
+    session_key: str,
+    ctx: Context,
+) -> dict:
+    """Delete a specific agent session.
+
+    Args:
+        agent_key: str, The agent key. Required.
+        session_key: str, The session key. Required.
+
+    Returns:
+        dict: Confirmation of deletion.
+    """
+    error = _validate_api_key_available()
+    if error:
+        return {"error": error}
+
+    if not agent_key or not session_key:
+        return {"error": "agent_key and session_key are required."}
+
+    if ctx:
+        ctx.info(f"Deleting session {session_key} for agent {agent_key}")
+
+    try:
+        return await _make_api_request(
+            f"{_server.VECTARA_BASE_URL}/agents/{agent_key}/sessions/{session_key}",
+            ctx=ctx,
+            error_context="delete session",
+            method="DELETE",
+        )
+    except Exception as e:
+        return {"error": _format_error("delete session", e)}
+
+
+# ---------------------------------------------------------------------------
+# Chat / Interaction Tools
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def chat_with_agent(
+    agent_key: str,
+    session_key: str,
+    message: str,
+    ctx: Context,
+) -> dict:
+    """Send a message to a Vectara agent and get a response.
+
+    This sends a text message to an existing agent session and returns
+    the agent's response. The agent may use its configured tools (search,
+    web, etc.) to answer.
+
+    Args:
+        agent_key: str, The agent key. Required.
+        session_key: str, The session key. Required.
+        message: str, The message to send. Required.
+
+    Returns:
+        dict: Agent response including output text, tool calls, and events.
+    """
+    error = _validate_api_key_available()
+    if error:
+        return {"error": error}
+
+    if not agent_key or not session_key:
+        return {"error": "agent_key and session_key are required."}
+    if not message:
+        return {"error": "message is required."}
+
+    if ctx:
+        ctx.info(f"Chatting with agent {agent_key}: {message[:100]}")
+
+    try:
+        payload = {
+            "type": "input_message",
+            "messages": [
+                {"type": "text", "content": message}
+            ],
+            "stream_response": False,
+        }
+
+        result = await _make_api_request(
+            f"{_server.VECTARA_BASE_URL}/agents/{agent_key}/sessions/{session_key}/events",
+            payload=payload,
+            ctx=ctx,
+            error_context="chat with agent",
+            method="POST",
+        )
+
+        return _extract_chat_response(result)
+    except Exception as e:
+        return {"error": _format_error("chat with agent", e)}
+
+
+def _extract_chat_response(result: dict) -> dict:
+    """Extract a clean response from the agent events payload."""
+    events = result.get("events", [])
+    if not events:
+        return result
+
+    response = {
+        "agent_output": "",
+        "tool_calls": [],
+        "events_summary": [],
+    }
+
+    for event in events:
+        event_type = event.get("type", "")
+        if event_type == "agent_output":
+            response["agent_output"] = event.get("content", "") or event.get("text", "")
+        elif event_type == "structured_output":
+            response["agent_output"] = json.dumps(event.get("fields", {}))
+        elif event_type == "tool_input":
+            response["tool_calls"].append({
+                "tool": event.get("tool_config_name", ""),
+                "arguments": event.get("arguments", {}),
+            })
+        elif event_type == "tool_output":
+            last_tool = response["tool_calls"][-1] if response["tool_calls"] else None
+            if last_tool:
+                last_tool["output"] = event.get("output", "")
+        response["events_summary"].append({
+            "type": event_type,
+            "id": event.get("id", ""),
+        })
+
+    if not response["tool_calls"]:
+        del response["tool_calls"]
+
+    return response
+
+
+@mcp.tool()
+async def list_events(
+    agent_key: str,
+    session_key: str,
+    ctx: Context,
+    limit: int = 20,
+    page_key: str = "",
+) -> dict:
+    """List conversation events (messages, tool calls, outputs) in a session.
+
+    Args:
+        agent_key: str, The agent key. Required.
+        session_key: str, The session key. Required.
+        limit: int, Max events to return per page. Default 20.
+        page_key: str, Pagination key from a previous response. Optional.
+
+    Returns:
+        dict: List of events and pagination metadata.
+    """
+    error = _validate_api_key_available()
+    if error:
+        return {"error": error}
+
+    if not agent_key or not session_key:
+        return {"error": "agent_key and session_key are required."}
+
+    if ctx:
+        ctx.info(f"Listing events for session {session_key}")
+
+    try:
+        params = {"limit": limit}
+        if page_key:
+            params["page_key"] = page_key
+
+        return await _make_api_request(
+            f"{_server.VECTARA_BASE_URL}/agents/{agent_key}/sessions/{session_key}/events",
+            ctx=ctx,
+            error_context="list events",
+            method="GET",
+            params=params,
+        )
+    except Exception as e:
+        return {"error": _format_error("list events", e)}

--- a/vectara_mcp/server.py
+++ b/vectara_mcp/server.py
@@ -6,6 +6,7 @@ import logging
 import os
 import signal
 import sys
+from urllib.parse import urlencode
 
 import aiohttp
 from mcp.server.fastmcp import FastMCP, Context
@@ -23,7 +24,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Constants
-VECTARA_BASE_URL = "https://api.vectara.io/v2"
+VECTARA_BASE_URL = os.getenv("VECTARA_BASE_URL", "https://api.vectara.io/v2")
 VHC_MODEL_NAME = "vhc-large-1.0"
 DEFAULT_LANGUAGE = "en"
 API_KEY_ERROR_MESSAGE = (
@@ -151,7 +152,7 @@ async def _handle_http_response(
     Raises:
         RuntimeError: With descriptive error message based on status code
     """
-    if response.status == 200:
+    if response.status in (200, 201):
         return await response.json()
     if response.status == 400:
         error_text = await response.text()
@@ -169,21 +170,25 @@ async def _handle_http_response(
 
 async def _make_api_request(
     url: str,
-    payload: dict,
+    payload: dict = None,
     ctx: Context = None,
     api_key_override: str = None,
-    error_context: str = "API"
+    error_context: str = "API",
+    method: str = "POST",
+    params: dict = None
 ) -> dict:
-    """Generic HTTP POST request with progress reporting and error handling.
+    """Generic HTTP request with progress reporting and error handling.
 
     Uses persistent connection pooling and circuit breaker pattern.
 
     Args:
         url: The API endpoint URL
-        payload: Request payload
+        payload: Request payload (for POST/PATCH/PUT)
         ctx: MCP context for progress reporting
         api_key_override: Optional API key override for testing
         error_context: Context for error messages
+        method: HTTP method (GET, POST, PATCH, PUT, DELETE)
+        params: Query parameters (for GET requests)
 
     Returns:
         dict: API response data
@@ -201,19 +206,25 @@ async def _make_api_request(
         await ctx.report_progress(0, 1)
 
     try:
-        # Use persistent session with circuit breaker protection
-        response = await conn_manager.request(
-            method='POST',
-            url=url,
-            headers=headers,
-            json_data=payload
-        )
+        request_kwargs = {
+            "method": method.upper(),
+            "url": url,
+            "headers": headers,
+        }
+        if payload is not None and method.upper() in ("POST", "PATCH", "PUT"):
+            request_kwargs["json_data"] = payload
+        if params:
+            request_kwargs["url"] = f"{url}?{urlencode(params)}"
+
+        response = await conn_manager.request(**request_kwargs)
 
         if ctx:
             await ctx.report_progress(1, 1)
 
         # Handle response using existing logic
         async with response:
+            if method.upper() == "DELETE" and response.status == 204:
+                return {"status": "deleted"}
             return await _handle_http_response(response, error_context)
 
     except Exception as e:  # pylint: disable=broad-exception-caught
@@ -711,6 +722,7 @@ def _setup_cleanup():
 
 def main():
     """Command-line interface for starting the Vectara MCP Server."""
+    import vectara_mcp.agents  # noqa: F401  — registers agent tools with mcp
     parser = argparse.ArgumentParser(description="Vectara MCP Server")
     parser.add_argument(
         '--transport',


### PR DESCRIPTION
## Summary
- Adds 11 new MCP tools for Vectara Agents: agent CRUD, session management, and chat
- Extends `_make_api_request` to support GET/PATCH/DELETE (was POST-only)
- Makes `VECTARA_BASE_URL` configurable via env var for on-prem/staging deployments

### New tools
| Tool | Method | Endpoint |
|---|---|---|
| `list_agents` | GET | `/v2/agents` |
| `get_agent` | GET | `/v2/agents/{agent_key}` |
| `create_agent` | POST | `/v2/agents` |
| `update_agent` | PATCH | `/v2/agents/{agent_key}` |
| `delete_agent` | DELETE | `/v2/agents/{agent_key}` |
| `create_session` | POST | `/v2/agents/{agent_key}/sessions` |
| `list_sessions` | GET | `/v2/agents/{agent_key}/sessions` |
| `get_session` | GET | `/v2/agents/{agent_key}/sessions/{session_key}` |
| `delete_session` | DELETE | `/v2/agents/{agent_key}/sessions/{session_key}` |
| `chat_with_agent` | POST | `/v2/agents/{agent_key}/sessions/{session_key}/events` |
| `list_events` | GET | `/v2/agents/{agent_key}/sessions/{session_key}/events` |

## Test plan
- [x] 104 unit tests pass (42 new agent + 62 existing)
- [x] 11 integration tests pass against staging
- [x] Existing tools (ask_vectara, search_vectara, etc.) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)